### PR TITLE
Fix GitHub Actions Workflow for Publishing to PyPI

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -143,7 +143,7 @@ jobs:
     name: Publish to PyPI (on tag)
     needs: tests
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') && env.PYPI_API_TOKEN != ''
+    if: startsWith(github.ref, 'refs/tags/') && secrets.PYPI_API_TOKEN != ''
     env:
       PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
     steps:


### PR DESCRIPTION
This pull request addresses an issue in the GitHub Actions workflow where the 'env' variable was incorrectly referenced as 'env.PYPI_API_TOKEN'. The condition for executing the publish job now correctly checks the 'secrets.PYPI_API_TOKEN' instead, which resolves the error related to unrecognized named values. This change ensures that the workflow can successfully publish to PyPI when a tag is pushed and the API token is available.

---

> This pull request was co-created with Cosine Genie

Original Task: [AI1/0rxo6m7navhw](https://cosine.sh/sywt8ah7e7gq/AI1/task/0rxo6m7navhw)
Author: foxcube3
